### PR TITLE
Sleep timer to prevent backstuff lag

### DIFF
--- a/src/main/java/gregtech/api/capability/impl/AbstractRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/AbstractRecipeLogic.java
@@ -8,6 +8,7 @@ import gregtech.api.metatileentity.MTETrait;
 import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.recipes.Recipe;
 import gregtech.api.recipes.RecipeMap;
+import gregtech.api.util.GTLog;
 import gregtech.api.util.GTUtility;
 import gregtech.common.ConfigHolder;
 import net.minecraft.item.ItemStack;
@@ -59,6 +60,7 @@ public abstract class AbstractRecipeLogic extends MTETrait implements IWorkable 
 
     private int sleepTimer = 0;
     private int sleepTime = 1;
+    private int failCount = 0;
 
     public AbstractRecipeLogic(MetaTileEntity tileEntity, RecipeMap<?> recipeMap) {
         super(tileEntity);
@@ -127,10 +129,15 @@ public abstract class AbstractRecipeLogic extends MTETrait implements IWorkable 
                 if (progressTime == 0 && sleepTimer == 0) {
                     boolean result = trySearchNewRecipe();
                     if (!result) {
+                        failCount++;
+                        if (failCount == 5) {
+                            sleepTime = Math.min(sleepTime * 2, 40);
+                            failCount = 0;
+                        }
                         sleepTimer = sleepTime;
-                        sleepTime = Math.max(sleepTime * 2, 40);
                     } else {
                         sleepTime = 1;
+                        failCount = 0;
                     }
                 }
                 sleepTimer = Math.max(0, sleepTimer - 1);

--- a/src/main/java/gregtech/api/capability/impl/AbstractRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/AbstractRecipeLogic.java
@@ -8,7 +8,6 @@ import gregtech.api.metatileentity.MTETrait;
 import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.recipes.Recipe;
 import gregtech.api.recipes.RecipeMap;
-import gregtech.api.util.GTLog;
 import gregtech.api.util.GTUtility;
 import gregtech.common.ConfigHolder;
 import net.minecraft.item.ItemStack;

--- a/src/main/java/gregtech/api/capability/impl/AbstractRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/AbstractRecipeLogic.java
@@ -139,7 +139,8 @@ public abstract class AbstractRecipeLogic extends MTETrait implements IWorkable 
                         failCount = 0;
                     }
                 }
-                sleepTimer = Math.max(0, sleepTimer - 1);
+                if (sleepTimer > 0)
+                    sleepTimer--;
             }
             if (wasActiveAndNeedsUpdate) {
                 this.wasActiveAndNeedsUpdate = false;

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityMultiFurnace.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityMultiFurnace.java
@@ -100,7 +100,7 @@ public class MetaTileEntityMultiFurnace extends RecipeMapMultiblockController {
         }
 
         @Override
-        protected void trySearchNewRecipe() {
+        protected boolean trySearchNewRecipe() {
             long maxVoltage = getMaxVoltage();
             Recipe currentRecipe = null;
             IItemHandlerModifiable importInventory = getInputInventory();
@@ -123,7 +123,9 @@ public class MetaTileEntityMultiFurnace extends RecipeMapMultiblockController {
             }
             if (currentRecipe != null && setupAndConsumeRecipeInputs(currentRecipe)) {
                 setupRecipe(currentRecipe);
+                return true;
             }
+            return false;
         }
 
         @Override


### PR DESCRIPTION
Adds a sleep timer to the Abstract Recipe Logic class. If no recipe is found the machine sleeps for x ticks. After 5 fails x is doubled up to a maximum of 40 ticks.