### PR TITLE
Jei recipe categories

### DIFF
--- a/src/main/java/gregtech/api/GTValues.java
+++ b/src/main/java/gregtech/api/GTValues.java
@@ -3,6 +3,7 @@ package gregtech.api;
 import net.minecraftforge.fml.common.Loader;
 import net.minecraftforge.oredict.OreDictionary;
 
+import java.text.DecimalFormat;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
@@ -91,5 +92,9 @@ public class GTValues {
         isModLoadedCache.put(modid, isLoaded);
         return isLoaded;
     }
+
+    public static final DecimalFormat thousandFormat = new DecimalFormat(",###");
+
+    public static final DecimalFormat thousandTwoPlaceFormat = new DecimalFormat(",##0.00");
 
 }

--- a/src/main/java/gregtech/api/gui/Widget.java
+++ b/src/main/java/gregtech/api/gui/Widget.java
@@ -269,7 +269,7 @@ public abstract class Widget {
     }
 
     @SideOnly(Side.CLIENT)
-    protected static void drawItemStack(ItemStack itemStack, int x, int y, @Nullable String altTxt) {
+    public static void drawItemStack(ItemStack itemStack, int x, int y, @Nullable String altTxt) {
         GlStateManager.pushMatrix();
         GlStateManager.translate(0.0F, 0.0F, 32.0F);
         GlStateManager.color(1F, 1F, 1F, 1F);

--- a/src/main/java/gregtech/integration/jei/GTJeiPlugin.java
+++ b/src/main/java/gregtech/integration/jei/GTJeiPlugin.java
@@ -99,7 +99,7 @@ public class GTJeiPlugin implements IModPlugin {
         for (RecipeMap<?> recipeMap : RecipeMap.getRecipeMaps()) {
             List<GTRecipeWrapper> recipesList = recipeMap.getRecipeList()
                 .stream().filter(recipe -> !recipe.isHidden() && recipe.hasValidInputsForDisplay())
-                .map(GTRecipeWrapper::new)
+                .map(recipe -> new GTRecipeWrapper(recipeMap, recipe))
                 .collect(Collectors.toList());
             registry.addRecipes(recipesList, GTValues.MODID + ":" + recipeMap.unlocalizedName);
         }

--- a/src/main/java/gregtech/integration/jei/recipe/GTRecipeWrapper.java
+++ b/src/main/java/gregtech/integration/jei/recipe/GTRecipeWrapper.java
@@ -74,7 +74,6 @@ public class GTRecipeWrapper implements IRecipeWrapper {
             recipeInputs.forEach(stack -> {
                 if (stack.amount == 0) {
                     notConsumedFluidInput.add(stack);
-                    stack.amount = 1;
                 }
             });
             ingredients.setInputs(VanillaTypes.FLUID, recipeInputs);

--- a/src/main/java/gregtech/integration/jei/recipe/RecipeMapCategory.java
+++ b/src/main/java/gregtech/integration/jei/recipe/RecipeMapCategory.java
@@ -8,9 +8,7 @@ import gregtech.api.gui.ModularUI;
 import gregtech.api.gui.Widget;
 import gregtech.api.gui.widgets.SlotWidget;
 import gregtech.api.gui.widgets.TankWidget;
-import gregtech.api.recipes.CountableIngredient;
 import gregtech.api.recipes.RecipeMap;
-import gregtech.integration.jei.utils.JEIHelpers;
 import gregtech.integration.jei.utils.render.FluidStackTextRenderer;
 import gregtech.integration.jei.utils.render.ItemStackTextRenderer;
 import mezz.jei.api.IGuiHelper;
@@ -92,7 +90,9 @@ public class RecipeMapCategory implements IRecipeCategory<GTRecipeWrapper> {
                         slotWidget.getPosition().x, slotWidget.getPosition().y, slotWidget.getSize().getWidth(), slotWidget.getSize().getHeight(), 0, 0);
                 } else if (handle.getItemHandler() == exportItems) {
                     //this is output item stack slot widget, so add it to item group
-                    itemStackGroup.init(importItems.getSlots() + handle.getSlotIndex(), false, new ItemStackTextRenderer(true),
+                    int slot = this.importItems.getSlots() + handle.getSlotIndex();
+                    int[] chances = recipeWrapper.getChanceEntries().get(slot);
+                    itemStackGroup.init(slot, false, new ItemStackTextRenderer(chances != null ? chances[0] : 0, chances != null ? chances[1] : 0),
                         slotWidget.getPosition().x, slotWidget.getPosition().y, slotWidget.getSize().getWidth(), slotWidget.getSize().getHeight(), 0, 0);
                 }
             } else if (uiWidget instanceof TankWidget) {

--- a/src/main/java/gregtech/integration/jei/recipe/RecipeMapCategory.java
+++ b/src/main/java/gregtech/integration/jei/recipe/RecipeMapCategory.java
@@ -8,8 +8,11 @@ import gregtech.api.gui.ModularUI;
 import gregtech.api.gui.Widget;
 import gregtech.api.gui.widgets.SlotWidget;
 import gregtech.api.gui.widgets.TankWidget;
+import gregtech.api.recipes.CountableIngredient;
 import gregtech.api.recipes.RecipeMap;
+import gregtech.integration.jei.utils.JEIHelpers;
 import gregtech.integration.jei.utils.render.FluidStackTextRenderer;
+import gregtech.integration.jei.utils.render.ItemStackTextRenderer;
 import mezz.jei.api.IGuiHelper;
 import mezz.jei.api.gui.IDrawable;
 import mezz.jei.api.gui.IGuiFluidStackGroup;
@@ -85,14 +88,12 @@ public class RecipeMapCategory implements IRecipeCategory<GTRecipeWrapper> {
                 SlotItemHandler handle = (SlotItemHandler) slotWidget.getHandle();
                 if (handle.getItemHandler() == importItems) {
                     //this is input item stack slot widget, so add it to item group
-                    itemStackGroup.init(handle.getSlotIndex(), true,
-                        slotWidget.getPosition().x,
-                        slotWidget.getPosition().y);
+                    itemStackGroup.init(handle.getSlotIndex(), true, new ItemStackTextRenderer(recipeWrapper.getIngredientConsumable().get(handle.getSlotIndex())),
+                        slotWidget.getPosition().x, slotWidget.getPosition().y, slotWidget.getSize().getWidth(), slotWidget.getSize().getHeight(), 0, 0);
                 } else if (handle.getItemHandler() == exportItems) {
                     //this is output item stack slot widget, so add it to item group
-                    itemStackGroup.init(importItems.getSlots() + handle.getSlotIndex(), false,
-                        slotWidget.getPosition().x,
-                        slotWidget.getPosition().y);
+                    itemStackGroup.init(importItems.getSlots() + handle.getSlotIndex(), false, new ItemStackTextRenderer(true),
+                        slotWidget.getPosition().x, slotWidget.getPosition().y, slotWidget.getSize().getWidth(), slotWidget.getSize().getHeight(), 0, 0);
                 }
             } else if (uiWidget instanceof TankWidget) {
                 TankWidget tankWidget = (TankWidget) uiWidget;

--- a/src/main/java/gregtech/integration/jei/utils/render/FluidStackTextRenderer.java
+++ b/src/main/java/gregtech/integration/jei/utils/render/FluidStackTextRenderer.java
@@ -5,7 +5,6 @@ import gregtech.api.util.TextFormattingUtil;
 import mezz.jei.api.gui.IDrawable;
 import mezz.jei.plugins.vanilla.ingredients.fluid.FluidStackRenderer;
 import net.minecraft.client.Minecraft;
-import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.client.renderer.GlStateManager;
 import net.minecraftforge.fluids.FluidStack;
 
@@ -31,10 +30,9 @@ public class FluidStackTextRenderer extends FluidStackRenderer {
 
         GlStateManager.pushMatrix();
         GlStateManager.scale(0.5, 0.5, 1);
-        FontRenderer fontRenderer = Minecraft.getMinecraft().fontRenderer;
 
         String s = amount > 0 ? TextFormattingUtil.formatLongToCompactString(fluidStack.amount, 4) + "L" : "NC";
-        fontRenderer.drawStringWithShadow(s, (xPosition + 6) * 2 - fontRenderer.getStringWidth(s) + 21, (yPosition + 12) * 2, amount > 0 ? 0xFFFFFF : 0xFFEC00);
+        minecraft.fontRenderer.drawStringWithShadow(s, (xPosition + 6) * 2 - minecraft.fontRenderer.getStringWidth(s) + 21, (yPosition + 12) * 2, amount > 0 ? 0xFFFFFF : 0xFFEC00);
 
         GlStateManager.popMatrix();
 

--- a/src/main/java/gregtech/integration/jei/utils/render/FluidStackTextRenderer.java
+++ b/src/main/java/gregtech/integration/jei/utils/render/FluidStackTextRenderer.java
@@ -9,6 +9,7 @@ import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.client.renderer.GlStateManager;
 import net.minecraftforge.fluids.FluidStack;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 public class FluidStackTextRenderer extends FluidStackRenderer {
@@ -17,21 +18,24 @@ public class FluidStackTextRenderer extends FluidStackRenderer {
     }
 
     @Override
-    public void render(Minecraft minecraft, final int xPosition, final int yPosition, @Nullable FluidStack fluidStack) {
+    public void render(@Nonnull Minecraft minecraft, final int xPosition, final int yPosition, @Nullable FluidStack fluidStack) {
         if (fluidStack == null)
             return;
-
+        int amount = fluidStack.amount;
+        if (amount < 1)
+            fluidStack.amount = 1;
         GlStateManager.disableBlend();
 
         RenderUtil.drawFluidForGui(fluidStack, fluidStack.amount, xPosition, yPosition, 17, 17);
+        fluidStack.amount = amount;
 
         GlStateManager.pushMatrix();
         GlStateManager.scale(0.5, 0.5, 1);
-
-        String s = TextFormattingUtil.formatLongToCompactString(fluidStack.amount, 4) + "L";
-
         FontRenderer fontRenderer = Minecraft.getMinecraft().fontRenderer;
-        fontRenderer.drawStringWithShadow(s, (xPosition + 6) * 2 - fontRenderer.getStringWidth(s) + 21, (yPosition + 12) * 2, 0xFFFFFF);
+
+        String s = amount > 0 ? TextFormattingUtil.formatLongToCompactString(fluidStack.amount, 4) + "L" : "NC";
+        fontRenderer.drawStringWithShadow(s, (xPosition + 6) * 2 - fontRenderer.getStringWidth(s) + 21, (yPosition + 12) * 2, amount > 0 ? 0xFFFFFF : 0xFFEC00);
+
         GlStateManager.popMatrix();
 
         GlStateManager.enableBlend();

--- a/src/main/java/gregtech/integration/jei/utils/render/ItemStackTextRenderer.java
+++ b/src/main/java/gregtech/integration/jei/utils/render/ItemStackTextRenderer.java
@@ -1,0 +1,32 @@
+package gregtech.integration.jei.utils.render;
+
+import gregtech.api.gui.Widget;
+import mezz.jei.plugins.vanilla.ingredients.item.ItemStackRenderer;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.GlStateManager;
+import net.minecraft.item.ItemStack;
+import org.jetbrains.annotations.Nullable;
+
+import javax.annotation.Nonnull;
+
+public class ItemStackTextRenderer extends ItemStackRenderer {
+
+    private final boolean consumable;
+
+    public ItemStackTextRenderer(boolean consumable) {
+        this.consumable = consumable;
+    }
+
+    @Override
+    public void render(@Nonnull Minecraft minecraft, int xPosition, int yPosition, @Nullable ItemStack ingredient) {
+        if (ingredient == null) return;
+        Widget.drawItemStack(ingredient, xPosition + 1, yPosition + 1, null);
+        if (!this.consumable && !ingredient.isEmpty()) {
+            GlStateManager.pushMatrix();
+            GlStateManager.scale(0.5, 0.5, 1);
+            minecraft.fontRenderer.drawStringWithShadow("NC", (xPosition + 6) * 2 - minecraft.fontRenderer.getStringWidth("NC") + 21, (yPosition + 13) * 2, 0xFFEC00);
+            GlStateManager.popMatrix();
+            GlStateManager.enableBlend();
+        }
+    }
+}

--- a/src/main/java/gregtech/integration/jei/utils/render/ItemStackTextRenderer.java
+++ b/src/main/java/gregtech/integration/jei/utils/render/ItemStackTextRenderer.java
@@ -1,32 +1,53 @@
 package gregtech.integration.jei.utils.render;
 
+import gregtech.api.GTValues;
 import gregtech.api.gui.Widget;
 import mezz.jei.plugins.vanilla.ingredients.item.ItemStackRenderer;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.item.ItemStack;
 import org.jetbrains.annotations.Nullable;
+import org.lwjgl.input.Keyboard;
 
 import javax.annotation.Nonnull;
 
 public class ItemStackTextRenderer extends ItemStackRenderer {
 
     private final boolean consumable;
+    private final int chance;
+    private final int boost;
+
+    public ItemStackTextRenderer(int chance, int boost) {
+        this(true, chance, boost);
+    }
 
     public ItemStackTextRenderer(boolean consumable) {
+        this(consumable, 0, 0);
+    }
+
+    public ItemStackTextRenderer(boolean consumable, int chance, int boost) {
         this.consumable = consumable;
+        this.chance = chance;
+        this.boost = boost;
     }
 
     @Override
     public void render(@Nonnull Minecraft minecraft, int xPosition, int yPosition, @Nullable ItemStack ingredient) {
         if (ingredient == null) return;
         Widget.drawItemStack(ingredient, xPosition + 1, yPosition + 1, null);
-        if (!this.consumable && !ingredient.isEmpty()) {
-            GlStateManager.pushMatrix();
-            GlStateManager.scale(0.5, 0.5, 1);
+        GlStateManager.pushMatrix();
+        GlStateManager.scale(0.5, 0.5, 1);
+        if (!this.consumable && !ingredient.isEmpty())
             minecraft.fontRenderer.drawStringWithShadow("NC", (xPosition + 6) * 2 - minecraft.fontRenderer.getStringWidth("NC") + 21, (yPosition + 13) * 2, 0xFFEC00);
-            GlStateManager.popMatrix();
-            GlStateManager.enableBlend();
+        if (this.chance > 0 && !(Keyboard.isKeyDown(Keyboard.KEY_LSHIFT) || Keyboard.isKeyDown(Keyboard.KEY_RSHIFT))) {
+            String chance = GTValues.thousandTwoPlaceFormat.format(this.chance / 100.0) + "%";
+            minecraft.fontRenderer.drawStringWithShadow(chance, (xPosition + 6) * 2 - minecraft.fontRenderer.getStringWidth(chance) + 21, (yPosition + 13) * 2, 0xFFEC00);
         }
+        if (this.boost > 0 && (Keyboard.isKeyDown(Keyboard.KEY_LSHIFT) || Keyboard.isKeyDown(Keyboard.KEY_RSHIFT))) {
+            String boost = "+" + GTValues.thousandTwoPlaceFormat.format(this.boost / 100.0) + "%";
+            minecraft.fontRenderer.drawStringWithShadow(boost, (xPosition + 6) * 2 - minecraft.fontRenderer.getStringWidth(boost) + 21, (yPosition + 13) * 2, 0xFFEC00);
+        }
+        GlStateManager.popMatrix();
+        GlStateManager.enableBlend();
     }
 }


### PR DESCRIPTION
- Add indicators for non-consumable and chanced outputs in JEI recipes. 
- Hold shift to view boost per tier instead of base chance.